### PR TITLE
Filter boolean environment variables

### DIFF
--- a/config-docker.php
+++ b/config-docker.php
@@ -43,12 +43,12 @@ define( 'YOURLS_LANG', getenv('YOURLS_LANG') ?: '' );
 /** Allow multiple short URLs for a same long URL
  ** Set to true to have only one pair of shortURL/longURL (default YOURLS behavior)
  ** Set to false to allow multiple short URLs pointing to the same long URL (bit.ly behavior) */
-define( 'YOURLS_UNIQUE_URLS', getenv('YOURLS_UNIQUE_URLS') !== 'false' );
+define( 'YOURLS_UNIQUE_URLS', getenv('YOURLS_UNIQUE_URLS') === false ?: filter_var(getenv('YOURLS_UNIQUE_URLS'), FILTER_VALIDATE_BOOLEAN) );
 
 /** Private means the Admin area will be protected with login/pass as defined below.
  ** Set to false for public usage (eg on a restricted intranet or for test setups)
  ** Read http://yourls.org/privatepublic for more details if you're unsure */
-define( 'YOURLS_PRIVATE', getenv('YOURLS_PRIVATE') !== 'false' );
+define( 'YOURLS_PRIVATE', getenv('YOURLS_PRIVATE') === false ?: filter_var(getenv('YOURLS_PRIVATE'), FILTER_VALIDATE_BOOLEAN) );
 
 /** A random secret hash used to encrypt cookies. You don't have to remember it, make it long and complicated. Hint: copy from http://yourls.org/cookie **/
 define( 'YOURLS_COOKIEKEY', getenv('YOURLS_COOKIEKEY') ?: 'modify this text with something random' );


### PR DESCRIPTION
> Current version evaluates everything that is not `"false"` to be true. It should still be possible to use 0 or 1 as values, since they are valid booleans as well
> 
> ( https://github.com/YOURLS/docker-yourls/pull/23#issuecomment-471453286 )